### PR TITLE
38 beliefs support all json data types

### DIFF
--- a/spec/src/agent/Belief.spec.js
+++ b/spec/src/agent/Belief.spec.js
@@ -1,21 +1,35 @@
 const Belief = require('../../../src/agent/Belief')
 
 describe('belief()', () => {
-  console.warn = jasmine.createSpy('log')
+  console.warn = jasmine.createSpy('warn')
 
   it('should create a new belief with the specified key and value', () => {
     expect(Belief('test', 'test')).toEqual({ test: 'test' })
   })
 
-  it('should throw a warning if belief is not JSON.stringify-able', () => {
+  it('should not throw a warning if belief is of a JSON data type', () => {
+    console.warn.calls.reset()
     // eslint-disable-next-line no-unused-vars
-    const belief = Belief('test', () => 'test')
-    expect(console.warn).toHaveBeenCalledWith('JS-son: Created belief with non-JSON object value')
+    const beliefs = {
+      ...Belief('number', 1),
+      ...Belief('string', 'string'),
+      ...Belief('null', null),
+      ...Belief('array', [])
+    }
+    expect(console.warn).not.toHaveBeenCalledWith('JS-son: Created belief with non-JSON object, non-JSON data type value')
   })
 
   it('should not throw warning if belief is JSON.stringify-able', () => {
+    console.warn.calls.reset()
     // eslint-disable-next-line no-unused-vars
-    const belief = Belief('test', {})
-    expect(console.warn).not.toHaveBeenCalledWith({})
+    const belief = Belief('object', {})
+    expect(console.warn).not.toHaveBeenCalledWith('JS-son: Created belief with non-JSON object, non-JSON data type value')
+  })
+
+  it('should throw a warning if belief is not JSON.stringify-able and not of a JSON data type', () => {
+    console.warn.calls.reset()
+    // eslint-disable-next-line no-unused-vars
+    const belief = Belief('function', () => {})
+    expect(console.warn).toHaveBeenCalledWith('JS-son: Created belief with non-JSON object, non-JSON data type value')
   })
 })

--- a/src/agent/Belief.js
+++ b/src/agent/Belief.js
@@ -1,4 +1,4 @@
-const warning = 'JS-son: Created belief with non-JSON object value'
+const warning = 'JS-son: Created belief with non-JSON object, non-JSON data type value'
 
 /**
  * JS-son agent belief generator
@@ -10,7 +10,10 @@ const Belief = (id, value) => {
   const belief = {}
   belief[id] = value
   try {
-    if (JSON.parse(JSON.stringify(belief)) !== belief) console.warn(warning)
+    const parsedBelief = JSON.parse(JSON.stringify(belief))
+    if (Object.keys(parsedBelief).length !== Object.keys(belief).length) {
+      console.warn(warning)
+    }
   } catch (error) {
     console.warn(warning)
   }


### PR DESCRIPTION
In addition to JSON objects, this commit adds support for

* string
* number
* array
* boolean
* null

Closes #38