### PR TITLE
#58 specify default preference generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,11 +328,7 @@ const desiresIntrospective = {
 ```
 
 The agents desires are mutually exclusive.
-Hence, the agents' intentions merely relay their desires, which is reflected in the following preference function generator:
-
-```JavaScript
-const preferenceFunctionGen = (beliefs, desires) => desireKey => desires[desireKey](beliefs)
-```
+Hence, the agents' intentions merely relay their desires, which is reflected by the default preference function generator.
 
 The agents' plans are to disseminate the announcement (``true`` or ``false``) as determined by the desire functions:
 
@@ -370,8 +366,7 @@ const createAgents = () => {
       `${type}${index}`,
       { ...beliefs, ...Belief('type', type) },
       desires,
-      plans,
-      preferenceFunctionGen
+      plans
     )
   })
   const numberBeliefsTrue = Object.keys(state).filter(

--- a/examples/arena/README.md
+++ b/examples/arena/README.md
@@ -163,7 +163,7 @@ const desires = {
 }
 ```
 
-From the desires, we jump directly to plans (see the provided function ``(beliefs, desires) => desireKey => desires[desireKey](beliefs)`` further below, which is generically applicable for this purpose).
+From the desires, we jump directly to plans.
 The plans simply relay the determined desire to the environment.
 
 ```javascript
@@ -212,8 +212,7 @@ const generateAgents = initialState => initialState.positions.map((position, ind
     index,
     beliefs,
     desires,
-    plans,
-    (beliefs, desires) => desireKey => desires[desireKey](beliefs)
+    plans
   )
 })
 ```

--- a/examples/arena/src/js/Arena.js
+++ b/examples/arena/src/js/Arena.js
@@ -75,8 +75,7 @@ const generateAgents = initialState => initialState.positions.map((position, ind
     index,
     beliefs,
     desires,
-    plans,
-    (beliefs, desires) => desireKey => desires[desireKey](beliefs)
+    plans
   )
 })
 

--- a/examples/jupyter/JS-son_Data_Science_Demo.ipynb
+++ b/examples/jupyter/JS-son_Data_Science_Demo.ipynb
@@ -187,23 +187,8 @@
    "metadata": {},
    "source": [
     "The agents desires are mutually exclusive. Hence, the agents' intentions merely relay their desires,\n",
-    "which is reflected in the following preference function generator:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%%node\n",
-    "const preferenceFunctionGen = (beliefs, desires) => desireKey => desires[desireKey](beliefs)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
+    "which is reflected in the default preference function generator ``(beliefs, desires) => desireKey => desires[desireKey](beliefs)``.\n",
+    "\n",
     "The agents' plans are to disseminate the announcement (``true`` or ``false``) as determined by the\n",
     "desire functions:"
    ]
@@ -270,8 +255,7 @@
     "      `${type}${index}`,\n",
     "      { ...beliefs, ...Belief('type', type) },\n",
     "      desires,\n",
-    "      plans,\n",
-    "      preferenceFunctionGen\n",
+    "      plans\n",
     "    )\n",
     "  })\n",
     "  const numberBeliefsTrue = Object.keys(state).filter(\n",

--- a/examples/node/full.js
+++ b/examples/node/full.js
@@ -100,11 +100,9 @@ const desiresIntrospective = {
 
 /*
 The agents desires are mutually exclusive. Hence, the agents' intentions merely relay their desires,
-which is reflected in the following preference function generator:
-*/
-const preferenceFunctionGen = (beliefs, desires) => desireKey => desires[desireKey](beliefs)
+which is reflected by the default preference function generator
+``(beliefs, desires) => desireKey => desires[desireKey](beliefs)``
 
-/*
 The agents' plans are to disseminate the announcement (``true`` or ``false``) as determined by the
 desire functions:
 */
@@ -141,8 +139,7 @@ const createAgents = () => {
       `${type}${index}`,
       { ...beliefs, ...Belief('type', type) },
       desires,
-      plans,
-      preferenceFunctionGen
+      plans
     )
   })
   const numberBeliefsTrue = Object.keys(state).filter(

--- a/spec/src/agent/Agent.spec.js
+++ b/spec/src/agent/Agent.spec.js
@@ -32,4 +32,10 @@ describe('Agent / next()', () => {
     agent.start()
     expect(agent.next({ ...Belief('dogNice', false) }).length).toEqual(0)
   })
+
+  it('should apply the default preference function generation if no other is specified', () => {
+    const defaultPreferenceAgent = new Agent('myAgent', beliefs, desires, plans)
+    defaultPreferenceAgent.start()
+    expect(defaultPreferenceAgent.next({ ...beliefs, dogHungry: true }).length).toEqual(2)
+  })
 })

--- a/spec/src/environment/GridWorld.spec.js
+++ b/spec/src/environment/GridWorld.spec.js
@@ -18,8 +18,7 @@ const agents = [1, 2, 3].map(value => new Agent(
   value,
   { ...Belief('testBelief', value) },
   desires,
-  plans,
-  (beliefs, desires) => desireKey => desires[desireKey](beliefs)
+  plans
 ))
 
 const fieldType = FieldType(

--- a/src/agent/Agent.js
+++ b/src/agent/Agent.js
@@ -6,11 +6,19 @@ const Intentions = require('./Intentions')
  * @param {object} beliefs initial beliefs of the agents
  * @param {object} desires the agent's desires
  * @param {array} plans the agent's plans
- * @param {function} determinePreferences preference function
+ * @param {function} determinePreferences preference function generator; by default
+                                          (if no function is provided), the preference function
+                                          turns all desires into intentions
  * @returns {object} JS-son agent object
  */
 
-function Agent (id, beliefs, desires, plans, determinePreferences) {
+function Agent (
+  id,
+  beliefs,
+  desires,
+  plans,
+  determinePreferences = (beliefs, desires) => desireKey => desires[desireKey](beliefs)
+) {
   this.id = id
   this.beliefs = beliefs
   this.desires = desires


### PR DESCRIPTION
specify a default determinePreferences value for the Agent object type:
the generated function essentially returns all desires as intentions