### PR TITLE
#92 add self-update capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,21 @@ const plansPorter = [
 ]
 ```
 
+Note that an agent can activate its own beliefs (and also plans or any other property it has) in the **body** of its plan (not in a plan *head*).
+For this, simply re-assign the corresponding property, for example as follows:
+
+```JavaScript
+Plan(
+    beliefs => beliefs.door.locked && beliefs.requests.includes('unlock'),
+    function () {
+      this.beliefs.door.locked = false
+      return [{ door: 'unlock' }]
+    }
+  )
+```
+Note that it is necessary to use the ``function`` keyword so that *JS-son* can set the scope of the plan body correctly.
+The feature can be activated for an agent by instantiating it with the ``selfUpdatesPossible`` set to ``false``.
+
 We instantiate a new agent with the belief set and plans.
 Because we are not making use of  *desires* in this simple belief-plan scenario, we pass an empty object as the agent's desires:
 

--- a/spec/src/agent/Agent.spec.js
+++ b/spec/src/agent/Agent.spec.js
@@ -1,4 +1,5 @@
 const Belief = require('../../../src/agent/Belief')
+const Plan = require('../../../src/agent/Plan')
 const Agent = require('../../../src/agent/Agent')
 
 const {
@@ -37,5 +38,38 @@ describe('Agent / next()', () => {
     const defaultPreferenceAgent = new Agent('myAgent', beliefs, desires, plans)
     defaultPreferenceAgent.start()
     expect(defaultPreferenceAgent.next({ ...beliefs, dogHungry: true }).length).toEqual(2)
+  })
+
+  it('should allow belief updates as part of the agent\'s internal reasoning loop', () => {
+    const newPlans = []
+    newPlans.concat(plans)
+    newPlans.push(Plan(
+      () => true,
+      function () {
+        this.beliefs.test = true
+        return {
+          actions: ['Good dog!']
+        }
+      }
+    ))
+    const newAgent = new Agent('myAgent', beliefs, desires, newPlans, preferenceFunctionGen)
+    newAgent.next()
+    expect(newAgent.beliefs.test).toBe(true)
+  })
+
+  it('should not allow dynamic belief updates if this feature is deactivate', () => {
+    const newPlans = []
+    newPlans.concat(plans)
+    newPlans.push(Plan(
+      () => true,
+      function () {
+        this.beliefs.test = true
+        return {
+          actions: ['Good dog!']
+        }
+      }
+    ))
+    const newAgent = new Agent('myAgent', beliefs, desires, newPlans, preferenceFunctionGen, false)
+    expect(() => newAgent.next()).toThrow(new TypeError("Cannot set property 'test' of undefined"))
   })
 })

--- a/src/agent/Plan.js
+++ b/src/agent/Plan.js
@@ -9,7 +9,9 @@ const Plan = (head, body) => ({
   head,
   body,
   // run: executed body if head is true; else: return null
-  run: beliefs => head(beliefs) === true ? body(beliefs) : null
+  run: function (beliefs) {
+    return head(beliefs) === true ? body.apply(this, [beliefs]) : null
+  }
 })
 
 module.exports = Plan


### PR DESCRIPTION
Enable agents to update their own beliefs, plans, et cetera via the body of any of their plans. Make the feature deactivatable when instantiating an agent.

Closes #92