### PR TITLE
#94 implement default messaging support

### DIFF
--- a/README.md
+++ b/README.md
@@ -482,6 +482,30 @@ Finally, we run 50 iterations of the scenario:
 environment.run(50)
 ```
 
+## Messaging
+JS-son agents can send "private" messages to any other JS-son agent, which the environment will then relay to this agent only.
+Agents can send these messages in the same way they register the execution of an action as the result of a plan.
+For example, in the plan below, an agent sends the message ``'Hi!'`` to the agent with the ID ``alice``:
+
+```JavaScript
+const messagePlans = [
+  Plan(_ => true, () => ({ messages: [{ message: 'Hi!', agentId: 'alice' }] }))
+]
+```
+
+Assuming that the sending agent has the ID ``bob``, the agent ``alice`` will receive the following belief update:
+
+```JavaScript
+beliefs = {
+  ...beliefs,
+  messages: {
+    bob: ['Hi!']
+  }
+}
+```
+
+Note that messages do not need to be strings, but can be of any type, for example objects.
+
 ## Further Examples
 
 ### Data Science

--- a/spec/integration/beliefPlan.spec.js
+++ b/spec/integration/beliefPlan.spec.js
@@ -23,6 +23,7 @@ const { updateMAS } = require('../mocks/environment')
 describe('Integration: belief-plan approach', () => {
   const human = new Agent('human', beliefs, desires, plans, preferenceFunctionGen)
   const dog = new Agent('dog', dogBeliefs, dogDesires, dogPlans, dogPreferenceFunctionGen)
+  const emptyMessageObject = { human: {}, dog: {} }
 
   const state = {
     dogNice: true,
@@ -39,12 +40,14 @@ describe('Integration: belief-plan approach', () => {
       dogNice: true,
       dogHungry: true,
       foodAvailable: false,
-      dogRecentlyPraised: false
+      dogRecentlyPraised: false,
+      messages: emptyMessageObject
     }, {
       dogNice: true,
       dogHungry: false,
       foodAvailable: false,
-      dogRecentlyPraised: false
+      dogRecentlyPraised: false,
+      messages: emptyMessageObject
     }]
     expect(history).toEqual(expectedHistory)
   })

--- a/spec/integration/full.spec.js
+++ b/spec/integration/full.spec.js
@@ -23,6 +23,7 @@ const { updateMAS } = require('../mocks/environment')
 describe('Environment / run()', () => {
   const human = new Agent('human', beliefs, desires, plans, preferenceFunctionGen)
   const dog = new Agent('dog', dogBeliefs, dogDesires, dogPlans, dogPreferenceFunctionGen)
+  const emptyMessageObject = { human: {}, dog: {} }
 
   const state = {
     dogNice: true,
@@ -39,12 +40,15 @@ describe('Environment / run()', () => {
       dogNice: true,
       dogHungry: true,
       foodAvailable: false,
-      dogRecentlyPraised: false
+      dogRecentlyPraised: false,
+      messages: emptyMessageObject
+
     }, {
       dogNice: true,
       dogHungry: false,
       foodAvailable: false,
-      dogRecentlyPraised: false
+      dogRecentlyPraised: false,
+      messages: emptyMessageObject
     }]
     expect(history).toEqual(expectedHistory)
   })

--- a/src/environment/Environment.js
+++ b/src/environment/Environment.js
@@ -22,9 +22,13 @@ function Environment (
     }
   }
 ) {
-  this.agents = {}
-  agents.forEach(agent => (this.agents[agent.id] = agent))
+  state.messages = {}
   this.state = state
+  this.agents = {}
+  agents.forEach(agent => {
+    this.agents[agent.id] = agent
+    this.state.messages[agent.id] = {}
+  })
   this.update = update
   this.render = render
   this.stateFilter = stateFilter
@@ -35,9 +39,34 @@ function Environment (
     this.history.push(this.state)
     const run = () => {
       Object.keys(this.agents).forEach(agentKey => {
+        const messages = {}
+        Object.keys(this.state.messages).forEach(recipient => {
+          Object.keys(this.state.messages[recipient]).forEach(sender => {
+            if (recipient !== agentKey) {
+              messages[sender] = []
+              return
+            }
+            messages[sender] = this.state.messages[recipient][sender]
+          })
+        })
+        const preFilteredState = { ...this.state, messages }
         const proposedUpdate = this.agents[agentKey].next(
-          this.stateFilter(this.state, agentKey, this.agents[agentKey].beliefs)
-        )
+          this.stateFilter(preFilteredState, agentKey, this.agents[agentKey].beliefs))
+        proposedUpdate.forEach(action => {
+          Object.keys(this.state.messages).forEach(key => {
+            if (this.state.messages[key][agentKey]) this.state.messages[key][agentKey] = []
+          })
+          if (action.messages) {
+            action.messages.forEach(
+              message => {
+                if (!this.state.messages[[message.agentId]][agentKey]) {
+                  this.state.messages[[message.agentId]][agentKey] = []
+                }
+                this.state.messages[message.agentId][agentKey].push(message.message)
+              }
+            )
+          }
+        })
         const stateUpdate = this.update(proposedUpdate, agentKey, this.state)
         this.state = {
           ...this.state,


### PR DESCRIPTION
Allow JS-son agents to send one or several "private" messages as part of a plan to one or several agents.
Closes #94.
Status: documentation still missing.