### PR TITLE
Update TD titles and associated URLs to lower case

### DIFF
--- a/examples/wot/agent.js
+++ b/examples/wot/agent.js
@@ -3,7 +3,7 @@ const { Belief, Plan, Agent } = require('js-son-agent')
 
 // eslint-disable-next-line
 WoT.produce({
-  title: 'Robot',
+  title: 'robot',
   description: 'A mock of a WoT assembly line robot for packaging and quality control',
   support: 'https://github.com/TimKam/JS-son',
   '@context': [
@@ -191,7 +191,7 @@ WoT.produce({
   const robot = thingToAgent(thing, plans)
   setInterval(() => {
     // eslint-disable-next-line
-    WoTHelpers.fetch('http://localhost:8080/Production_line').then(async (td) => {
+    WoTHelpers.fetch('http://localhost:8080/production_line').then(async (td) => {
       // eslint-disable-next-line
       let productionLine = await WoT.consume(td)
       const itemsOnLine = await productionLine.readProperty('itemsOnLine')

--- a/examples/wot/production.js
+++ b/examples/wot/production.js
@@ -14,7 +14,7 @@ let temperature
 
 // eslint-disable-next-line
 WoT.produce({
-  title: 'Production_line',
+  title: 'production_line',
   description: 'A WoT production line mock',
   support: 'https://github.com/TimKam/JS-son',
   '@context': [
@@ -90,7 +90,7 @@ WoT.produce({
   setInterval(() => {
     speedHistory.push(speed)
     // eslint-disable-next-line
-    WoTHelpers.fetch('http://localhost:8080/Thermometer').then(async (td) => {
+    WoTHelpers.fetch('http://localhost:8080/thermometer').then(async (td) => {
       // eslint-disable-next-line
       let thermometer = await WoT.consume(td)
       temperature = await thermometer.invokeAction(

--- a/examples/wot/thermometer.js
+++ b/examples/wot/thermometer.js
@@ -5,7 +5,7 @@
 */
 // eslint-disable-next-line
 WoT.produce({
-  title: 'Thermometer',
+  title: 'thermometer',
   description: 'A WoT thermometer mock',
   support: 'https://github.com/TimKam/JS-son',
   '@context': [


### PR DESCRIPTION
The latest version of Thingweb Node-WoT exposes URIs using TD titles in lower case, e.g. for the title `Production_line` the exposed URI would be `/production_line`. Request URIs are case sensitive, so this update triggered a couple of `404`s when running the example. The commit in this PR updates the titles and request URIs to lower case.