### PR TITLE
#115 add goal support

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,61 @@ Finally, we run 20 iterations of the scenario:
 environment.run(20)
 ```
 
+### Goal-based Approach
+JS-son supports an alternative goal-based reasoning loop. Here, we show a minimal working example of an agent that employs this approach.
+Our agent has merely one goal:
+
+```JavaScript
+const goals = {
+  praiseDog: Goal('praiseDog', false, { dogName: 'Hasso' })
+}
+```
+
+The goal has the ID ``praiseDog``, is ``false`` (when starting) and has the property ``dogname``, which is ``Hasso``.
+The agent starts with the belief that Hasso has not been a nice dog:
+
+```JavaScript
+const beliefs = {
+  ...Belief('dogNice', false)
+}
+```
+
+The agent's *goal revision function*  takes the agent's current beliefs and goals and returns a revised goal object (that can feature new goals, revised goals, and/or have previously existing goals removed):
+
+```JavaScript
+const reviseGoals = (beliefs, goals) => {
+  if (beliefs.dogNice) {
+    goals.praiseDog.isActive = true
+  }
+  return goals
+}
+```
+
+Our agent has only one plan, which is attached to the ``praiseDog`` goal, *i.e.*, if the goal is active, the plan is executed (the agent praises the dog):
+
+```JavaScript
+const plans = [ Plan(goals.praiseDog, () => ({ action: 'Good dog!' })) ]
+```
+
+Based on the goals, beliefs, goal revision function, and plans, we instantiate the agent:
+
+```JavaScript
+const newAgent = new Agent({
+  id: 'MyAgent',
+  beliefs,
+  goals,
+  plans,
+  reviseGoals
+})
+```
+
+Finally, we run the agent's reasoning loop for one iteration, and provide an updated belief update the dog's niceness:
+
+```JavaScript
+newAgent.next({ ...Belief('dogNice', true) }
+```
+Note that this activates the ``praiseDog`` goal and hence triggers the execution of the agent's only plan.
+
 ### Belief-Desire-Intention-Plan Approach
 In this tutorial, we implement a simple information spread simulation, using JS-son's full belief-desire-intention-plan approach.
 We simulate the spread of a single boolean belief among 100 agents.

--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ const goals = {
 }
 ```
 
-The goal has the ID ``praiseDog``, is ``false`` (when starting) and has the property ``dogname``, which is ``Hasso``.
+The goal has the ID ``praiseDog``, is ``false`` (when starting) and has a ``value`` object with the property ``dogname``, which is ``Hasso``.
 The agent starts with the belief that Hasso has not been a nice dog:
 
 ```JavaScript
@@ -293,12 +293,12 @@ const reviseGoals = (beliefs, goals) => {
 }
 ```
 
-Our agent has only one plan, which is attached to the ``praiseDog`` goal, *i.e.*, if the goal is active, the plan is executed (the agent praises the dog):
+Our agent has only one plan, which is attached to the ``praiseDog`` goal, *i.e.*, if the goal is active, the plan's *body* function is executed (the agent praises the dog):
 
 ```JavaScript
-const plans = [ Plan(goals.praiseDog, () => ({ action: 'Good dog!' })) ]
+const plans = [ Plan(goals.praiseDog, (beliefs, goalValue) => ({ action: `Good dog, ${goalValue.dogName}!` })) ]
 ```
-
+Note that the value of a plan's goal can be accessed in the body of the plan.
 Based on the goals, beliefs, goal revision function, and plans, we instantiate the agent:
 
 ```JavaScript

--- a/spec/src/agent/Agent.spec.js
+++ b/spec/src/agent/Agent.spec.js
@@ -197,7 +197,7 @@ describe('Agent / next(), configuration object-based', () => {
       }
       return goals
     }
-    const plans = [ Plan(goals.praiseDog, () => ({ action: 'Good dog!' })) ]
+    const plans = [ Plan(goals.praiseDog, (belief, goalValue) => ({ action: `Good dog, ${goalValue.dogName}!` })) ]
     const newAgent = new Agent({
       id: 'MyAgent',
       beliefs,
@@ -205,6 +205,6 @@ describe('Agent / next(), configuration object-based', () => {
       plans,
       reviseGoals
     })
-    expect(newAgent.next({ ...Belief('dogNice', true) })[0].action).toEqual('Good dog!')
+    expect(newAgent.next({ ...Belief('dogNice', true) })[0].action).toEqual('Good dog, Hasso!')
   })
 })

--- a/spec/src/agent/Agent.spec.js
+++ b/spec/src/agent/Agent.spec.js
@@ -8,6 +8,7 @@ const {
   preferenceFunctionGen,
   plans
 } = require('../../mocks/human')
+const Goal = require('../../../src/agent/Goal')
 
 describe('Agent / next()', () => {
   const agent = new Agent('myAgent', beliefs, desires, plans, preferenceFunctionGen)
@@ -169,7 +170,7 @@ describe('Agent / next(), configuration object-based', () => {
     expect(() => newAgent.next()).toThrow(new TypeError("Cannot set property 'test' of undefined"))
   })
 
-  it('should allow for a custom belief revision function that rejects belief updates from the environment', () => {
+  it('should support a custom belief revision function that rejects belief updates from the environment', () => {
     const reviseBeliefs = (oldBeliefs, newBeliefs) => !newBeliefs.dogNice ? oldBeliefs : newBeliefs
     const newAgent = new Agent({
       id: 'myAgent',
@@ -181,5 +182,29 @@ describe('Agent / next(), configuration object-based', () => {
     })
     newAgent.next({ ...Belief('dogNice', false) })
     expect(newAgent.beliefs.dogNice).toBe(true)
+  })
+
+  it('should support a custom goal revision function, e.g. to determine which goals are active, which inactive', () => {
+    const beliefs = {
+      ...Belief('dogNice', false)
+    }
+    const goals = {
+      praiseDog: Goal('praiseDog', false, { dogName: 'Hasso' })
+    }
+    const reviseGoals = (beliefs, goals) => {
+      if (beliefs.dogNice) {
+        goals.praiseDog.isActive = true
+      }
+      return goals
+    }
+    const plans = [ Plan(goals.praiseDog, () => ({ action: 'Good dog!' })) ]
+    const newAgent = new Agent({
+      id: 'MyAgent',
+      beliefs,
+      goals,
+      plans,
+      reviseGoals
+    })
+    expect(newAgent.next({ ...Belief('dogNice', true) })[0].action).toEqual('Good dog!')
   })
 })

--- a/spec/src/agent/Belief.spec.js
+++ b/spec/src/agent/Belief.spec.js
@@ -1,5 +1,7 @@
 const Belief = require('../../../src/agent/Belief')
 
+const warning = 'JS-son: Created belief with non-JSON object, non-JSON data type value'
+
 describe('belief()', () => {
   console.warn = jasmine.createSpy('warn')
 
@@ -16,24 +18,20 @@ describe('belief()', () => {
       ...Belief('null', null),
       ...Belief('array', [])
     }
-    expect(console.warn).not.toHaveBeenCalledWith(
-      'JS-son: Created belief with non-JSON object, non-JSON data type value'
-    )
+    expect(console.warn).not.toHaveBeenCalledWith(warning)
   })
 
   it('should not throw warning if belief is JSON.stringify-able', () => {
     console.warn.calls.reset()
     // eslint-disable-next-line no-unused-vars
     const belief = Belief('object', {})
-    expect(console.warn).not.toHaveBeenCalledWith(
-      'JS-son: Created belief with non-JSON object, non-JSON data type value')
+    expect(console.warn).not.toHaveBeenCalledWith(warning)
   })
 
   it('should throw warning if belief isn\'t JSON.stringify-able & not of a JSON data type', () => {
     console.warn.calls.reset()
     // eslint-disable-next-line no-unused-vars
     const belief = Belief('function', () => {})
-    expect(console.warn).toHaveBeenCalledWith(
-      'JS-son: Created belief with non-JSON object, non-JSON data type value')
+    expect(console.warn).toHaveBeenCalledWith(warning)
   })
 })

--- a/spec/src/agent/Goal.spec.js
+++ b/spec/src/agent/Goal.spec.js
@@ -1,0 +1,40 @@
+const Goal = require('../../../src/agent/Goal')
+
+const warning = 'JS-son: Created goal with non-JSON object, non-JSON data type value';
+
+describe('goal()', () => {
+  console.warn = jasmine.createSpy('warn')
+
+  it('should create a new goal with the specified id, activeness status, and value', () => {
+    expect(Goal('test', false)).toEqual({ id: 'test', isActive: false })
+    expect(Goal('test', true, { intensity: 1 })).toEqual(
+      { id: 'test', isActive: true, value: { intensity: 1 } }
+    )
+  })
+
+  it('should not throw a warning if goal value is of a JSON data type', () => {
+    console.warn.calls.reset()
+    // eslint-disable-next-line no-unused-vars
+    const goals = {
+      ...Goal('number', true, 1),
+      ...Goal('string', true, 'string'),
+      ...Goal('null', true, null),
+      ...Goal('array', true, [])
+    }
+    expect(console.warn).not.toHaveBeenCalledWith(warning)
+  })
+
+  it('should not throw warning if goal is JSON.stringify-able', () => {
+    console.warn.calls.reset()
+    // eslint-disable-next-line no-unused-vars
+    const goal = Goal('object', true, {})
+    expect(console.warn).not.toHaveBeenCalledWith(warning)
+  })
+
+  it('should throw warning if goal isn\'t JSON.stringify-able & not of a JSON data type', () => {
+    console.warn.calls.reset()
+    // eslint-disable-next-line no-unused-vars
+    const goal = Goal('function', true, () => {})
+    expect(console.warn).toHaveBeenCalledWith(warning)
+  })
+})

--- a/spec/src/agent/Plan.spec.js
+++ b/spec/src/agent/Plan.spec.js
@@ -1,5 +1,6 @@
 const Intentions = require('../../../src/agent/Intentions')
 const Plan = require('../../../src/agent/Plan')
+const Goal = require('../../../src/agent/Goal')
 
 const {
   beliefs,
@@ -36,5 +37,24 @@ describe('Plan / run()', () => {
     }
     beliefs.dogName = 'Hasso'
     expect(praiseDog.run(beliefs)).toEqual(expectedPlanResult)
+  })
+
+  it('should support goal-based plans', () => {
+    const goal = Goal('praiseDog', true, { dogName: 'Hasso' })
+    const praiseDog = Plan(goal, (beliefs, goal) => ({
+      actions: [`Good dog, ${goal.value.dogName}!`]
+    }))
+    const expectedPlanResult = {
+      actions: ['Good dog, Hasso!']
+    }
+    expect(praiseDog.run(beliefs, goal)).toEqual(expectedPlanResult)
+  })
+
+  it('should not trigger goal-based plans for active goals', () => {
+    const goal = Goal('praiseDog', false, { dogName: 'Hasso' })
+    const praiseDog = Plan(goal, (beliefs, goal) => ({
+      actions: [`Good dog, ${goal.value.dogName}!`]
+    }))
+    expect(praiseDog.run(beliefs, goal)).toBe(null)
   })
 })

--- a/spec/src/agent/Plan.spec.js
+++ b/spec/src/agent/Plan.spec.js
@@ -41,8 +41,8 @@ describe('Plan / run()', () => {
 
   it('should support goal-based plans', () => {
     const goal = Goal('praiseDog', true, { dogName: 'Hasso' })
-    const praiseDog = Plan(goal, (beliefs, goal) => ({
-      actions: [`Good dog, ${goal.value.dogName}!`]
+    const praiseDog = Plan(goal, (beliefs, goalValue) => ({
+      actions: [`Good dog, ${goalValue.dogName}!`]
     }))
     const expectedPlanResult = {
       actions: ['Good dog, Hasso!']
@@ -53,7 +53,7 @@ describe('Plan / run()', () => {
   it('should not trigger goal-based plans for active goals', () => {
     const goal = Goal('praiseDog', false, { dogName: 'Hasso' })
     const praiseDog = Plan(goal, (beliefs, goal) => ({
-      actions: [`Good dog, ${goal.value.dogName}!`]
+      actions: [`Good dog, ${goal.dogName}!`]
     }))
     expect(praiseDog.run(beliefs, goal)).toBe(null)
   })

--- a/src/agent/Goal.js
+++ b/src/agent/Goal.js
@@ -1,0 +1,26 @@
+const warning = 'JS-son: Created goal with non-JSON object, non-JSON data type value'
+
+/**
+ * JS-son agent goal generator
+ * @param {string} id the goal's unique identifier
+ * @param {boolean} isActive indicates whether the goal is active or not
+ * @param {any} value the goal's value (optional)
+ * @returns {object} JS-son agent goal
+ */
+const Goal = (id, isActive, value) => {
+  const goal = {}
+  goal.id = id
+  goal.isActive = !!isActive // convert to boolean
+  if (value) goal.value = value
+  try {
+    const parsedGoal = JSON.parse(JSON.stringify(goal))
+    if (Object.keys(parsedGoal).length !== Object.keys(goal).length) {
+      console.warn(warning)
+    }
+  } catch (error) {
+    console.warn(warning)
+  }
+  return goal
+}
+
+module.exports = Goal

--- a/src/agent/Plan.js
+++ b/src/agent/Plan.js
@@ -1,6 +1,6 @@
 /**
  * JS-son plan generator
- * @param {function } head Determines if plan is active
+ * @param {function } head Determines if plan is active; can be a function or a JS-son goal
  * @param {function} body Determines what actions to execute
  * @returns {object} JS-plan
  */
@@ -10,7 +10,8 @@ const Plan = (head, body) => ({
   body,
   // run: executed body if head is true; else: return null
   run: function (beliefs) {
-    return head(beliefs) === true ? body.apply(this, [beliefs]) : null
+    return typeof head === 'function' ? head(beliefs) === true ? body.apply(this, [beliefs]) : null
+      : head.isActive ? body.apply(this, [beliefs, head]) : null
   }
 })
 

--- a/src/agent/Plan.js
+++ b/src/agent/Plan.js
@@ -11,7 +11,7 @@ const Plan = (head, body) => ({
   // run: executed body if head is true; else: return null
   run: function (beliefs) {
     return typeof head === 'function' ? head(beliefs) === true ? body.apply(this, [beliefs]) : null
-      : head.isActive ? body.apply(this, [beliefs, head]) : null
+      : head.isActive ? body.apply(this, [beliefs, head.value]) : null
   }
 })
 


### PR DESCRIPTION
Closes #115 

Goal-based reasoning loop:
Agent revises beliefs, then goals
Plans are attached to goals,
i.e., triggered if the corresponding goal is active